### PR TITLE
feat: make Redis support optional at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Validated providers:
 ### Deployment
 
 A set of dependencies required by this bundle, on top of the Sling Starter ones, is available at `src/main/features/main.json`.
+For the tokens to be stored in Redis ( see [#redis-storage] ) an additional feature with dependencies is found at `src/main/features/redis.json`. 
 
 Since the bundle relies on encryption to create and validate the OAuth 2.0 `state` parameter, a `CryptoService` must be configured
 

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,3 @@
+# Make Jedis imports optional, the bundle can work with JCR persistence only
+Import-Package: redis.clients.jedis;resolution:=optional, \
+    *;

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <skipAddFeatureDependencies>true</skipAddFeatureDependencies>
-                    <skipAddJarToFeature>false</skipAddJarToFeature>
-                    <jarStartOrder>25</jarStartOrder>
                     <framework>
                         <groupId>org.apache.felix</groupId>
                         <artifactId>org.apache.felix.framework</artifactId>
@@ -87,7 +85,7 @@
                     <aggregates>
                         <aggregate>
                             <classifier>app</classifier>
-                            <filesInclude>*.json</filesInclude>
+                            <filesInclude>main.json</filesInclude>
                             <includeArtifact>
                                 <groupId>org.apache.sling</groupId>
                                 <artifactId>org.apache.sling.starter</artifactId>

--- a/src/main/features/main.json
+++ b/src/main/features/main.json
@@ -28,22 +28,6 @@
         "id":"net.minidev:accessors-smart:2.5.1",
         "start-order": 24
      },
-    {
-        "id":"redis.clients:jedis:5.1.5",
-        "start-order": 24
-     },
-     {
-        "id": "org.apache.commons:commons-pool2:2.12.0",
-        "start-order": 24
-     },
-     {
-        "id": "com.google.code.gson:gson:2.11.0",
-        "start-order": 24
-     },
-     {
-        "id": "org.json:json:20231013",
-        "start-order": 24
-     },
      {
         "id": "org.apache.sling:org.apache.sling.commons.crypto:1.1.0",
         "start-order": 24
@@ -51,6 +35,10 @@
      {
         "id": "org.apache.servicemix.bundles:org.apache.servicemix.bundles.jasypt:1.9.3_1",
         "start-order": 24
+     },
+     {
+        "id": "${project.groupId}:${project.artifactId}:${project.version}",
+        "start-order": 25
      }
   ]
 }

--- a/src/main/features/redis.json
+++ b/src/main/features/redis.json
@@ -1,0 +1,20 @@
+{
+  "bundles": [
+    {
+        "id":"redis.clients:jedis:5.1.5",
+        "start-order": 24
+     },
+     {
+        "id": "org.apache.commons:commons-pool2:2.12.0",
+        "start-order": 24
+     },
+     {
+        "id": "com.google.code.gson:gson:2.11.0",
+        "start-order": 24
+     },
+     {
+        "id": "org.json:json:20231013",
+        "start-order": 24
+     }
+  ]
+}


### PR DESCRIPTION
The Redis persistence is only one variant, let's make it optional. I expect most users to start with the JCR persistence.