### PR TITLE
chore(deps): update to org.apache.sling.api 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.0</version>
+            <version>2.25.4</version>
             <scope>provided</scope>
         </dependency>
         <!-- TODO - revisit if we can remove dependency-->


### PR DESCRIPTION
This is the first released version not affected by CVE-2022-32549. The vulnerability has no impact on the bundle, but let's keep the security scanning tools happy.