### PR TITLE
build: widen slf4j import range and bump sling-bundle-parent to v66

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,3 +1,5 @@
 # Make Jedis imports optional, the bundle can work with JCR persistence only
-Import-Package: redis.clients.jedis;resolution:=optional, \
+# Widen slf4j import range to support both 1.7.x (Sling Starter 13) and 2.x
+Import-Package: org.slf4j;version="[1.7,3)", \
+    redis.clients.jedis;resolution:=optional, \
     *;

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 

--- a/src/test/java/org/apache/sling/auth/oauth_client/AuthorizationCodeFlowIT.java
+++ b/src/test/java/org/apache/sling/auth/oauth_client/AuthorizationCodeFlowIT.java
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -81,6 +82,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Testcontainers(disabledWithoutDocker = true)
 class AuthorizationCodeFlowIT {
 
     private static final Duration DEFAULT_AWAIT_DURATION = Duration.ofSeconds(10);

--- a/src/test/java/org/apache/sling/auth/oauth_client/impl/RedisOAuthTokenStoreTest.java
+++ b/src/test/java/org/apache/sling/auth/oauth_client/impl/RedisOAuthTokenStoreTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class RedisOAuthTokenStoreTest extends TokenStoreTestSupport<RedisOAuthTokenStore> {
 
     @Container


### PR DESCRIPTION
Updates build configuration and test robustness for broader compatibility.

- `bnd.bnd`: widen `org.slf4j` import version range to `[1.7,3)` to support both slf4j 1.7.x (Sling Starter 13) and 2.x
- `pom.xml`: bump `sling-bundle-parent` version from 62 to 66
- `AuthorizationCodeFlowIT`: add `@Testcontainers(disabledWithoutDocker = true)` so the integration test is skipped gracefully when Docker is unavailable
- `RedisOAuthTokenStoreTest`: change `@Testcontainers` to `@Testcontainers(disabledWithoutDocker = true)` for the same reason

Co-authored-by: Maia <maia@noreply>